### PR TITLE
Allow latest version of react to be used

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,8 +84,8 @@
     "classnames": "^2.2.5",
     "element-class": "^0.2.2",
     "lodash": "^4.16.1",
-    "react-addons-update": "^0.14.0 || <15.4.0",
-    "react-dom": "^0.14.0 || <15.4.0",
-    "react": "^0.14.0 || <15.4.0"
+    "react-addons-update": "^0.14.0",
+    "react-dom": "^0.14.0",
+    "react": "^0.14.0"
   }
 }


### PR DESCRIPTION
Locking in an old version of react means that react needs to be included twice in the bundle If you're using react 15.4.1. Leads to an extra 140 kb of dependencies, more than doubling the size of react-bootstrap-table.

<img width="615" alt="react-bootstrap-table" src="https://cloud.githubusercontent.com/assets/16856016/21537097/cc44deb8-cd51-11e6-8a5c-3af170436ca3.PNG">
